### PR TITLE
Add UI reset for best difficulty

### DIFF
--- a/main/http_server/axe-os/src/app/components/home/home.component.html
+++ b/main/http_server/axe-os/src/app/components/home/home.component.html
@@ -126,6 +126,9 @@
                         </div>
                         <span class="text-900 font-medium">{{info.bestSessionDiff}} </span>
                         <span class="text-500">since system boot</span>
+                        <div class="mt-2">
+                            <button pButton size="small" label="Reset" (click)="resetBestDiff()"></button>
+                        </div>
                         <!-- <span class="text-green-500 font-medium">520 </span>
                         <span class="text-500">newly registered</span> -->
                     </div>

--- a/main/http_server/axe-os/src/app/components/home/home.component.ts
+++ b/main/http_server/axe-os/src/app/components/home/home.component.ts
@@ -285,5 +285,9 @@ export class HomeComponent {
     });
 
     return this.calculateAverage(efficiencies);
-  }  
+  }
+
+  public resetBestDiff() {
+    this.systemService.resetBestDiff().subscribe();
+  }
 }

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -78,6 +78,10 @@ export class SystemService {
     return this.httpClient.post(`${uri}/api/system/restart`, {}, {responseType: 'text'});
   }
 
+  public resetBestDiff(uri: string = '') {
+    return this.httpClient.post(`${uri}/api/system/bestdiff/reset`, {}, {responseType: 'text'});
+  }
+
   public updateSystem(uri: string = '', update: any) {
     return this.httpClient.patch(`${uri}/api/system`, update);
   }

--- a/main/http_server/http_server.c
+++ b/main/http_server/http_server.c
@@ -35,6 +35,7 @@
 #include "connect.h"
 #include "asic.h"
 #include "TPS546.h"
+#include "system.h"
 #include "theme_api.h"  // Add theme API include
 #include "axe-os/api/system/asic_settings.h"
 #include "http_server.h"
@@ -516,6 +517,25 @@ static esp_err_t POST_restart(httpd_req_t * req)
     return ESP_OK;
 }
 
+static esp_err_t POST_reset_best_diff(httpd_req_t * req)
+{
+    if (is_network_allowed(req) != ESP_OK) {
+        return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");
+    }
+
+    if (set_cors_headers(req) != ESP_OK) {
+        httpd_resp_send_500(req);
+        return ESP_OK;
+    }
+
+    SYSTEM_reset_best_diff(GLOBAL_STATE);
+
+    const char * resp_str = "Best difficulty reset";
+    httpd_resp_send(req, resp_str, HTTPD_RESP_USE_STRLEN);
+
+    return ESP_OK;
+}
+
 
 /* Simple handler for getting system handler */
 static esp_err_t GET_system_info(httpd_req_t * req)
@@ -975,19 +995,35 @@ esp_err_t start_rest_server(void * pvParameters)
     httpd_register_uri_handler(server, &swarm_options_uri);
 
     httpd_uri_t system_restart_uri = {
-        .uri = "/api/system/restart", .method = HTTP_POST, 
-        .handler = POST_restart, 
+        .uri = "/api/system/restart", .method = HTTP_POST,
+        .handler = POST_restart,
         .user_ctx = rest_context
     };
     httpd_register_uri_handler(server, &system_restart_uri);
 
+    httpd_uri_t reset_best_diff_uri = {
+        .uri = "/api/system/bestdiff/reset",
+        .method = HTTP_POST,
+        .handler = POST_reset_best_diff,
+        .user_ctx = rest_context
+    };
+    httpd_register_uri_handler(server, &reset_best_diff_uri);
+
     httpd_uri_t system_restart_options_uri = {
-        .uri = "/api/system/restart", 
-        .method = HTTP_OPTIONS, 
-        .handler = handle_options_request, 
+        .uri = "/api/system/restart",
+        .method = HTTP_OPTIONS,
+        .handler = handle_options_request,
         .user_ctx = NULL
     };
     httpd_register_uri_handler(server, &system_restart_options_uri);
+
+    httpd_uri_t reset_best_diff_options_uri = {
+        .uri = "/api/system/bestdiff/reset",
+        .method = HTTP_OPTIONS,
+        .handler = handle_options_request,
+        .user_ctx = NULL
+    };
+    httpd_register_uri_handler(server, &reset_best_diff_options_uri);
 
     httpd_uri_t update_system_settings_uri = {
         .uri = "/api/system", 

--- a/main/http_server/openapi.yaml
+++ b/main/http_server/openapi.yaml
@@ -530,6 +530,21 @@ paths:
         '500':
           description: Internal server error
 
+  /api/system/bestdiff/reset:
+    post:
+      summary: Reset best difficulty
+      description: Reset stored best difficulty statistics
+      operationId: resetBestDifficulty
+      tags:
+        - system
+      responses:
+        '200':
+          description: Best difficulty reset
+        '401':
+          description: Unauthorized - Client not in allowed network range
+        '500':
+          description: Internal server error
+
   /api/system:
     patch:
       summary: Update system settings

--- a/main/system.c
+++ b/main/system.c
@@ -345,3 +345,16 @@ static esp_err_t ensure_overheat_mode_config() {
 
     return ESP_OK;
 }
+
+void SYSTEM_reset_best_diff(GlobalState * GLOBAL_STATE)
+{
+    SystemModule * module = &GLOBAL_STATE->SYSTEM_MODULE;
+
+    module->best_nonce_diff = 0;
+    module->best_session_nonce_diff = 0;
+
+    nvs_config_set_u64(NVS_CONFIG_BEST_DIFF, 0);
+
+    _suffix_string(0, module->best_diff_string, DIFF_STRING_SIZE, 0);
+    _suffix_string(0, module->best_session_diff_string, DIFF_STRING_SIZE, 0);
+}

--- a/main/system.h
+++ b/main/system.h
@@ -12,5 +12,6 @@ void SYSTEM_notify_rejected_share(GlobalState * GLOBAL_STATE, char * error_msg);
 void SYSTEM_notify_found_nonce(GlobalState * GLOBAL_STATE, double found_diff, uint8_t job_id);
 void SYSTEM_notify_mining_started(GlobalState * GLOBAL_STATE);
 void SYSTEM_notify_new_ntime(GlobalState * GLOBAL_STATE, uint32_t ntime);
+void SYSTEM_reset_best_diff(GlobalState * GLOBAL_STATE);
 
 #endif /* SYSTEM_H_ */


### PR DESCRIPTION
## Summary
- allow resetting the best difficulty stats via new API and UI control
- expose API route in OpenAPI docs
- add SystemService and UI helpers for new route

## Testing
- `npm test` *(fails: ng not found)*